### PR TITLE
Bite at higher energies if the gcd would end before next tick

### DIFF
--- a/tbc_cat_sim.py
+++ b/tbc_cat_sim.py
@@ -1319,8 +1319,11 @@ class Simulation():
             # Decision tree for Bite usage is more complicated, so there is
             # some duplicated logic with the main tree.
 
-            # Shred versus Bite decision is the same as vanilla criteria
-            if (energy >= 57) or ((energy >= 15) and self.player.omen_proc):
+            # Shred versus Bite decision is the same as vanilla criteria.
+
+            # Bite immediately if we'd have to wait for the following cast.
+            cutoff_modifier = 0 if time_to_next_tick <= 1.0 else 20
+            if (energy >= 57 + cutoff_modifier) or ((energy >= 15 + cutoff_modifier) and self.player.omen_proc):
                 return self.player.shred()
             if energy >= 35:
                 return self.player.bite()


### PR DESCRIPTION
Common wisdom has been that shift-shred-bite is better than
shift-shred-shred-bite, but the sim would sometimes
shift-shred-shred-bite in situations like this (ticks at even seconds)

1.5s Shift (60 energy)
2.0s Tick (80 energy)
3.0s Shred (38 energy)
4.0s Tick (58 energy)
4.0s Shred (16 energy)
6.0s Tick (36 energy)
6.0s Bite (0 energy)

Instead, we would expect that the shred at 4 seconds is a bite, followed
by a shift at 5 seconds.

Validation that this change is positive:

Rotation definitions
--------------------

Biteweave: Rip@4, Bite@4
Ripweave: Rip@4, Bite@5
Purebite: Bite@5

Before change
-------------

Default settings (7700, 0/5)

Biteweave: 2408.1
Ripweave:  2398.8
Purebite:  2336.8

7700, 5/5

Biteweave: 2444.3
Ripweave:  2441.0
Purebite:  2398.1

6200, 0/5

Biteweave: 2665.9
Ripweave:  2660.4
Purebite:  2620.4

6200, 5/5

Biteweave: 2705.4
Ripweave:  2707.4
Purebite:  2688.8

After change
------------

Default settings (7700, 0/5)

Biteweave: 2408.7
Ripweave:  2403.3
Purebite:  2343.2

7700, 5/5

Biteweave: 2446.3
Ripweave:  2446.6
Purebite:  2406.8

6200, 0/5

Biteweave: 2665.1
Ripweave:  2666.5
Purebite:  2628.3

6200, 5/5

Biteweave: 2707.4
Ripweave:  2713.0
Purebite:  2701.4